### PR TITLE
Cria flag para método ogr2ogr e para csv não codificado em utf8 e quebra de linha no formato dos.

### DIFF
--- a/src/run_mustache.py
+++ b/src/run_mustache.py
@@ -160,14 +160,22 @@ def main(argv):
             if listOfDict['layers'][key]['method']   == 'shp2sql':
                 listOfDict['layers'][key]['isCsv'] = False
                 listOfDict['layers'][key]['isOgr'] = False
+                listOfDict['layers'][key]['isOgrWithShp'] = False
                 listOfDict['layers'][key]['isShp'] = True
             elif listOfDict['layers'][key]['method'] == 'csv2sql':
                 listOfDict['layers'][key]['isCsv'] = True
                 listOfDict['layers'][key]['isOgr'] = False
+                listOfDict['layers'][key]['isOgrWithShp'] = False
                 listOfDict['layers'][key]['isShp'] = False
             elif listOfDict['layers'][key]['method'] == 'ogr2ogr':
                 listOfDict['layers'][key]['isCsv'] = False
                 listOfDict['layers'][key]['isOgr'] = True
+                listOfDict['layers'][key]['isOgrWithShp'] = False
+                listOfDict['layers'][key]['isShp'] = False
+            elif listOfDict['layers'][key]['method'] == 'ogrWshp':
+                listOfDict['layers'][key]['isCsv'] = False
+                listOfDict['layers'][key]['isOgr'] = False
+                listOfDict['layers'][key]['isOgrWithShp'] = False
                 listOfDict['layers'][key]['isShp'] = False
 
         #let listWithSeparators = pureList.map( (x, i, arr) => x.toString()+((arr.length-1===i)? '':', ') );

--- a/src/run_mustache.py
+++ b/src/run_mustache.py
@@ -158,11 +158,17 @@ def main(argv):
         # flags isCsv e isShp indicam se method é shp ou csv
         for key in listOfDict['layers'].keys():
             if listOfDict['layers'][key]['method']   == 'shp2sql':
-                listOfDict['layers'][key]['isShp'] = True
                 listOfDict['layers'][key]['isCsv'] = False
+                listOfDict['layers'][key]['isOgr'] = False
+                listOfDict['layers'][key]['isShp'] = True
             elif listOfDict['layers'][key]['method'] == 'csv2sql':
-                listOfDict['layers'][key]['isShp'] = False
                 listOfDict['layers'][key]['isCsv'] = True
+                listOfDict['layers'][key]['isOgr'] = False
+                listOfDict['layers'][key]['isShp'] = False
+            elif listOfDict['layers'][key]['method'] == 'ogr2ogr':
+                listOfDict['layers'][key]['isCsv'] = False
+                listOfDict['layers'][key]['isOgr'] = True
+                listOfDict['layers'][key]['isShp'] = False
 
         #let listWithSeparators = pureList.map( (x, i, arr) => x.toString()+((arr.length-1===i)? '':', ') );
         #let listOfObjects = pureList.map( x=> ({name:x}) )

--- a/src/run_mustache.py
+++ b/src/run_mustache.py
@@ -156,14 +156,13 @@ def main(argv):
         listOfDict['layers_keys'] = [*listOfDict['layers'].keys()]
 
         # flags que indicam tipo de method
-
-        listOfDict['layers'][key]['isCsv']              = False
-        listOfDict['layers'][key]['isCsvNotUtf8AndDos'] = False
-        listOfDict['layers'][key]['isOgr']              = False
-        listOfDict['layers'][key]['isOgrWithShp']       = False
-        listOfDict['layers'][key]['isShp']              = False
-
         for key in listOfDict['layers'].keys():
+            listOfDict['layers'][key]['isCsv']              = False
+            listOfDict['layers'][key]['isCsvNotUtf8AndDos'] = False
+            listOfDict['layers'][key]['isOgr']              = False
+            listOfDict['layers'][key]['isOgrWithShp']       = False
+            listOfDict['layers'][key]['isShp']              = False
+
             if listOfDict['layers'][key]['method']   == 'shp2sql':
                 listOfDict['layers'][key]['isShp'] = True
             elif listOfDict['layers'][key]['method'] == 'csv2sql':

--- a/src/run_mustache.py
+++ b/src/run_mustache.py
@@ -155,28 +155,25 @@ def main(argv):
         items_setLast(listOfDict['files'])
         listOfDict['layers_keys'] = [*listOfDict['layers'].keys()]
 
-        # flags isCsv e isShp indicam se method é shp ou csv
+        # flags que indicam tipo de method
+
+        listOfDict['layers'][key]['isCsv']              = False
+        listOfDict['layers'][key]['isCsvNotUtf8AndDos'] = False
+        listOfDict['layers'][key]['isOgr']              = False
+        listOfDict['layers'][key]['isOgrWithShp']       = False
+        listOfDict['layers'][key]['isShp']              = False
+
         for key in listOfDict['layers'].keys():
             if listOfDict['layers'][key]['method']   == 'shp2sql':
-                listOfDict['layers'][key]['isCsv'] = False
-                listOfDict['layers'][key]['isOgr'] = False
-                listOfDict['layers'][key]['isOgrWithShp'] = False
                 listOfDict['layers'][key]['isShp'] = True
             elif listOfDict['layers'][key]['method'] == 'csv2sql':
                 listOfDict['layers'][key]['isCsv'] = True
-                listOfDict['layers'][key]['isOgr'] = False
-                listOfDict['layers'][key]['isOgrWithShp'] = False
-                listOfDict['layers'][key]['isShp'] = False
             elif listOfDict['layers'][key]['method'] == 'ogr2ogr':
-                listOfDict['layers'][key]['isCsv'] = False
                 listOfDict['layers'][key]['isOgr'] = True
-                listOfDict['layers'][key]['isOgrWithShp'] = False
-                listOfDict['layers'][key]['isShp'] = False
             elif listOfDict['layers'][key]['method'] == 'ogrWshp':
-                listOfDict['layers'][key]['isCsv'] = False
-                listOfDict['layers'][key]['isOgr'] = False
-                listOfDict['layers'][key]['isOgrWithShp'] = False
-                listOfDict['layers'][key]['isShp'] = False
+                listOfDict['layers'][key]['isOgrWithShp'] = True
+            elif listOfDict['layers'][key]['method'] == 'csv2unix2utf8':
+                listOfDict['layers'][key]['isCsvNotUtf8AndDos'] = True
 
         #let listWithSeparators = pureList.map( (x, i, arr) => x.toString()+((arr.length-1===i)? '':', ') );
         #let listOfObjects = pureList.map( x=> ({name:x}) )


### PR DESCRIPTION
Adicionada flag para métodos do tipo ogr2ogr, conforme issue em https://github.com/AddressForAll/digital-preservation-BR/issues/17  e https://github.com/AddressForAll/digital-preservation-BR/issues/18.

Depende de https://github.com/digital-guard/preserv-BR/pull/5.